### PR TITLE
Fix #5 by running into_raw() in both debug and release builds

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -24,7 +24,7 @@ impl Drop for CustomWaker {
     }
 }
 
-impl ViaRawPointer for CustomWaker {
+unsafe impl ViaRawPointer for CustomWaker {
     type Target = ();
 
     fn into_raw(self) -> *mut Self::Target {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,8 @@ where
             // simply assert that the pointer has remained the same. This is
             // part of the ViaRawPointer safety contract, so we only check it
             // in debug builds.
-            debug_assert_eq!(waker.into_raw(), raw);
+            let waker_raw = waker.into_raw();
+            debug_assert_eq!(waker_raw, raw);
 
             let cloned_raw = cloned.into_raw();
             let cloned_raw = cloned_raw as *const ();
@@ -268,7 +269,9 @@ where
             let raw = raw as *mut T::Target;
             let waker: T = unsafe { ViaRawPointer::from_raw(raw) };
             waker.wake_by_ref();
-            debug_assert_eq!(waker.into_raw(), raw);
+
+            let waker_raw = waker.into_raw();
+            debug_assert_eq!(waker_raw, raw);
         },
         // Drop
         |raw| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //!
 //! // Usually in practice you'll be using an Arc or Box, which already
 //! // implement this, so there will be no need to implement it yourself.
-//! impl ViaRawPointer for StaticWaker {
+//! unsafe impl ViaRawPointer for StaticWaker {
 //!     type Target = ();
 //!
 //!     fn into_raw(self) -> *mut () {
@@ -144,6 +144,7 @@ use alloc::boxed::Box;
 use alloc::rc;
 use alloc::sync as arc;
 use core::{
+    mem::ManuallyDrop,
     ptr,
     task::{RawWaker, RawWakerVTable, Waker},
 };
@@ -152,11 +153,13 @@ use core::{
 /// Implementors must ensure that, for a given object, the pointer remains
 /// fixed as long as no mutable operations are performed (that is, calling
 /// from_ptr() followed by into_ptr(), with no mutable operations in between,
-/// the returned pointer has the same value.)
+/// the returned pointer has the same value.) Implementors also must not panic
+/// when the interface is used correctly. The Waker constructed by IntoWaker
+/// can cause a double drop if either of these functions panic.
 ///
 /// In the future, we hope to have a similar trait added to the standard
 /// library; see https://github.com/rust-lang/rust/issues/75846 for details.
-pub trait ViaRawPointer {
+pub unsafe trait ViaRawPointer {
     type Target: ?Sized;
 
     /// Convert this object into a raw pointer.
@@ -244,15 +247,14 @@ where
         |raw| {
             let raw = raw as *mut T::Target;
 
-            let waker: T = unsafe { ViaRawPointer::from_raw(raw) };
-            let cloned = waker.clone();
+            let waker = ManuallyDrop::<T>::new(unsafe { ViaRawPointer::from_raw(raw) });
+            let cloned: T = (*waker).clone();
 
             // We can't save the `into_raw` back into the raw waker, so we must
             // simply assert that the pointer has remained the same. This is
             // part of the ViaRawPointer safety contract, so we only check it
             // in debug builds.
-            let waker_raw = waker.into_raw();
-            debug_assert_eq!(waker_raw, raw);
+            debug_assert_eq!(ManuallyDrop::into_inner(waker).into_raw(), raw);
 
             let cloned_raw = cloned.into_raw();
             let cloned_raw = cloned_raw as *const ();
@@ -267,11 +269,10 @@ where
         // wake by ref
         |raw| {
             let raw = raw as *mut T::Target;
-            let waker: T = unsafe { ViaRawPointer::from_raw(raw) };
+            let waker = ManuallyDrop::<T>::new(unsafe { ViaRawPointer::from_raw(raw) });
             waker.wake_by_ref();
 
-            let waker_raw = waker.into_raw();
-            debug_assert_eq!(waker_raw, raw);
+            debug_assert_eq!(ManuallyDrop::into_inner(waker).into_raw(), raw);
         },
         // Drop
         |raw| {
@@ -303,7 +304,7 @@ impl<T: WakeRef + ?Sized> WakeRef for &T {
 
 impl<T: WakeRef + ?Sized> Wake for &T {}
 
-impl<T: ?Sized> ViaRawPointer for Box<T> {
+unsafe impl<T: ?Sized> ViaRawPointer for Box<T> {
     type Target = T;
 
     fn into_raw(self) -> *mut T {
@@ -329,7 +330,7 @@ impl<T: Wake> Wake for Box<T> {
     }
 }
 
-impl<T: ?Sized> ViaRawPointer for arc::Arc<T> {
+unsafe impl<T: ?Sized> ViaRawPointer for arc::Arc<T> {
     type Target = T;
 
     fn into_raw(self) -> *mut T {
@@ -350,7 +351,7 @@ impl<T: WakeRef + ?Sized> WakeRef for arc::Arc<T> {
 
 impl<T: WakeRef + ?Sized> Wake for arc::Arc<T> {}
 
-impl<T> ViaRawPointer for arc::Weak<T> {
+unsafe impl<T> ViaRawPointer for arc::Weak<T> {
     type Target = T;
 
     fn into_raw(self) -> *mut T {
@@ -378,7 +379,7 @@ impl<T: WakeRef + ?Sized> WakeRef for rc::Rc<T> {
     }
 }
 
-impl<T: ?Sized> ViaRawPointer for rc::Rc<T> {
+unsafe impl<T: ?Sized> ViaRawPointer for rc::Rc<T> {
     type Target = T;
 
     fn into_raw(self) -> *mut T {
@@ -397,7 +398,7 @@ impl<T: WakeRef + ?Sized> Wake for rc::Rc<T> {
     }
 }
 
-impl<T> ViaRawPointer for rc::Weak<T> {
+unsafe impl<T> ViaRawPointer for rc::Weak<T> {
     type Target = T;
 
     fn into_raw(self) -> *mut T {
@@ -418,7 +419,7 @@ impl<T: WakeRef + ?Sized> WakeRef for rc::Weak<T> {
 
 impl<T: WakeRef + ?Sized> Wake for rc::Weak<T> {}
 
-impl<T: ViaRawPointer> ViaRawPointer for Option<T>
+unsafe impl<T: ViaRawPointer> ViaRawPointer for Option<T>
 where
     T::Target: Sized,
 {
@@ -506,7 +507,7 @@ mod test {
         }
     }
 
-    impl ViaRawPointer for PanicWaker {
+    unsafe impl ViaRawPointer for PanicWaker {
         type Target = ();
 
         fn into_raw(self) -> *mut () {


### PR DESCRIPTION
Wakes were being dropped too many times in release builds because the `into_raw()` call that was also used as a sort of `mem::forget()` was placed inside a `debug_assert_eq!`, and so was not being run. This fixes the problem by always calling `into_raw()` outside of the assertion. Some alternatives would be to call `mem::forget()` directly, use `ManuallyDrop`, or make the `debug_assert_eq!` be an `assert_eq!`.