### PR TITLE
Add support for no-alloc environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,6 @@ license = "MPL-2.0"
 description = "A safe interface for creating async Wakers"
 repository = "https://github.com/Lucretiel/cooked-waker"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["alloc"]
+alloc = []

--- a/examples/static.rs
+++ b/examples/static.rs
@@ -1,0 +1,44 @@
+//! An example of how to work with statically-allocated wakers.
+
+use cooked_waker::{IntoWaker, WakeRef};
+
+use core::{
+    sync::atomic::{AtomicU32, Ordering},
+    task::Waker,
+};
+
+struct CustomWaker {
+    wake_count: AtomicU32,
+}
+impl Drop for CustomWaker {
+    fn drop(&mut self) {
+        println!("Drop is never called");
+    }
+}
+
+impl WakeRef for CustomWaker {
+    fn wake_by_ref(&self) {
+        let count = self.wake_count.fetch_add(1, Ordering::Relaxed);
+        println!("wake by ref #{}", count);
+    }
+}
+
+fn main() {
+    println!("Hello, world!");
+    static WAKER: CustomWaker = CustomWaker {
+        wake_count: AtomicU32::new(0),
+    };
+    let waker1: Waker = WAKER.into_waker();
+
+    let waker2 = waker1.clone();
+
+    // Clones of a waker from `<&'static T as IntoWaker>` will share the data pointer
+    println!("Waker1: {:?}", waker1);
+    println!("Waker2: {:?}", waker2);
+
+    waker1.wake_by_ref();
+    waker1.wake();
+
+    waker2.wake_by_ref();
+    waker2.wake();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,6 +309,18 @@ impl<T: WakeRef + ?Sized> WakeRef for &T {
 
 impl<T: WakeRef + ?Sized> Wake for &T {}
 
+unsafe impl<'a, T> ViaRawPointer for &'a T {
+    type Target = T;
+
+    fn into_raw(self) -> *mut Self::Target {
+        ptr::from_ref(self).cast_mut()
+    }
+
+    unsafe fn from_raw(ptr: *mut Self::Target) -> Self {
+        &*ptr
+    }
+}
+
 unsafe impl<T: ViaRawPointer> ViaRawPointer for Option<T>
 where
     T::Target: Sized,


### PR DESCRIPTION
This crate has a bunch of cool stuff, but all of it assumes you have access to an allocator, which I don't always have. I made some changes to support environments that don't have an allocator, and figured I'd send a PR in case you're interested.

All these changes should be backwards-compatible such that you could release this change as a v5.1.0.

Changes are:
* Put all uses of `alloc` behind an `alloc` feature flag
  * Enabled by default for backwards-compatibility
* Implement `ViaRawPointer` for `&'a T`
  * This turns into an implementation of `IntoWaker` for `&'static T` if `T: WakeByRef + Sync + Sized + 'static`

I also made an example that uses the new functions to run using a statically-allocated waker.